### PR TITLE
Fixed Storage Account to work with v.3.0 of Terraforms

### DIFF
--- a/azure/assets/terraform/terraform.tf
+++ b/azure/assets/terraform/terraform.tf
@@ -62,10 +62,11 @@ resource "azurerm_subnet" "azure_bats_subnet_2" {
 
 # Create a Storage Account in the azure_rg_bosh resouce group
 resource "azurerm_storage_account" "azure_bosh_sa" {
-  name                = "${replace(var.env_name, "-", "")}"
-  resource_group_name = "${azurerm_resource_group.azure_rg_bosh.name}"
-  location            = "${var.location}"
-  account_type        = "Standard_LRS"
+  name                     = "${replace(var.env_name, "-", "")}"
+  resource_group_name      = "${azurerm_resource_group.azure_rg_bosh.name}"
+  location                 = "${var.location}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 # Create a Storage Container for the bosh director
 resource "azurerm_storage_container" "azure_bosh_container" {


### PR DESCRIPTION
The terraform "Azure" provider v0.3.0 now requires "account_replication_type" and "account_tier". 

See this link for details - https://github.com/terraform-providers/terraform-provider-azurerm/commit/77d13c7608975a6c1a1ab4b8c9cedddd93557dda#diff-f4d2502d01b7fb77deb7bb221025fb51 