### PR TITLE
Force Terraform to use version 1.0.1 until bug is fixed in 1.1.0

### DIFF
--- a/azure/assets/terraform/terraform.tf
+++ b/azure/assets/terraform/terraform.tf
@@ -20,6 +20,7 @@ variable "environments" {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
+  version         = "~> 1.0.1"
   client_id       = "${var.azure_client_id}"
   client_secret   = "${var.azure_client_secret}"
   subscription_id = "${var.azure_subscription_id}"


### PR DESCRIPTION
The latest changes in the Terraform Azure Provider plugin breaks all Azure pipelines. This change will force it to fall back to version 1.0.1 which still works. We'll remove this once the latest version of the Azure Provider is fixed.