### PR TITLE
Optional prefix for resource group name

### DIFF
--- a/azure/assets/terraform/terraform.tf
+++ b/azure/assets/terraform/terraform.tf
@@ -17,6 +17,11 @@ variable "environments" {
     AzureChinaCloud   = "china"
   }
 }
+variable "resource_group_prefix" {
+  type    = "string"
+  default = ""
+}
+
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
@@ -29,7 +34,7 @@ provider "azurerm" {
 }
 # Create a resource group
 resource "azurerm_resource_group" "azure_rg_bosh" {
-  name     = "${var.env_name}-rg"
+  name     = "${var.resource_group_prefix}${var.env_name}-rg"
   location = "${var.location}"
 }
 # Create a virtual network in the azure_rg_bosh resource group


### PR DESCRIPTION
Add an optional prefix for resource group name, users can use this prefix to differ their resource group from others when they share the same subscription.