### PR TITLE
Replace outdated azurerm_storage_account argument

### DIFF
--- a/alicloud/assets/terraform/terraform.tf
+++ b/alicloud/assets/terraform/terraform.tf
@@ -9,157 +9,157 @@ terraform {
 }
 
 provider "alicloud" {
-  access_key = "${var.access_key}"
-  secret_key = "${var.secret_key}"
-  region = "${var.region}"
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.region
 }
 
 data "alicloud_zones" "default" {}
 
 # Create a VPC to launch our instances into
 resource "alicloud_vpc" "default" {
-  name = "${var.env_name}"
+  name       = var.env_name
   cidr_block = "172.16.0.0/16"
 }
 
 # Create an nat gateway to give our subnet access to the outside world
 resource "alicloud_nat_gateway" "default" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  name = "${var.env_name}"
+  vpc_id = alicloud_vpc.default.id
+  name   = var.env_name
 }
 
 resource "alicloud_snat_entry" "default" {
-  snat_table_id = "${alicloud_nat_gateway.default.snat_table_ids}"
-  source_vswitch_id = "${alicloud_vswitch.default.id}"
-  snat_ip = "${alicloud_eip.natgw.ip_address}"
+  snat_table_id     = alicloud_nat_gateway.default.snat_table_ids
+  source_vswitch_id = alicloud_vswitch.default.id
+  snat_ip           = alicloud_eip.natgw.ip_address
 }
 
 resource "alicloud_vswitch" "default" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  cidr_block = "${cidrsubnet(alicloud_vpc.default.cidr_block, 8, 0)}"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 0)
+  availability_zone = data.alicloud_zones.default.zones.0.id
 }
 
 resource "alicloud_snat_entry" "alicloud_resources" {
-  snat_table_id = "${alicloud_nat_gateway.default.snat_table_ids}"
-  source_vswitch_id = "${alicloud_vswitch.alicloud_resources.id}"
-  snat_ip = "${alicloud_eip.natgw.ip_address}"
+  snat_table_id     = alicloud_nat_gateway.default.snat_table_ids
+  source_vswitch_id = alicloud_vswitch.alicloud_resources.id
+  snat_ip           = alicloud_eip.natgw.ip_address
 }
 
 resource "alicloud_vswitch" "alicloud_resources" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  cidr_block = "${cidrsubnet(alicloud_vpc.default.cidr_block, 8, 1)}"
-  availability_zone = "${data.alicloud_zones.default.zones.0.id}"
-  name = "${var.env_name}-alicloud-resources"
+  vpc_id            = alicloud_vpc.default.id
+  cidr_block        = cidrsubnet(alicloud_vpc.default.cidr_block, 8, 1)
+  availability_zone = data.alicloud_zones.default.zones.0.id
+  name              = "${var.env_name}-alicloud-resources"
 }
 
 resource "alicloud_security_group" "allow_all" {
-  vpc_id = "${alicloud_vpc.default.id}"
-  name = "allow_all-${var.env_name}"
+  vpc_id      = alicloud_vpc.default.id
+  name        = "allow_all-${var.env_name}"
   description = "Allow local and concourse traffic"
 }
 
 resource "alicloud_security_group_rule" "all-in" {
-  type = "ingress"
-  ip_protocol = "all"
-  nic_type = "intranet"
-  policy = "accept"
-  port_range = "-1/-1"
-  priority = 1
-  security_group_id = "${alicloud_security_group.allow_all.id}"
-  cidr_ip = "0.0.0.0/0"
+  type              = "ingress"
+  ip_protocol       = "all"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "-1/-1"
+  priority          = 1
+  security_group_id = alicloud_security_group.allow_all.id
+  cidr_ip           = "0.0.0.0/0"
 }
 
 resource "alicloud_security_group_rule" "all-out" {
-  type = "egress"
-  ip_protocol = "all"
-  nic_type = "intranet"
-  policy = "accept"
-  port_range = "-1/-1"
-  priority = 1
-  security_group_id = "${alicloud_security_group.allow_all.id}"
-  cidr_ip = "0.0.0.0/0"
+  type              = "egress"
+  ip_protocol       = "all"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "-1/-1"
+  priority          = 1
+  security_group_id = alicloud_security_group.allow_all.id
+  cidr_ip           = "0.0.0.0/0"
 }
 
 resource "alicloud_eip" "director" {
-  name = "${var.env_name}-director"
-  bandwidth = "10"
+  name                 = "${var.env_name}-director"
+  bandwidth            = "10"
   internet_charge_type = "PayByBandwidth"
 }
 
 resource "alicloud_eip" "bats" {
-  name = "${var.env_name}-bats"
-  bandwidth = "10"
+  name                 = "${var.env_name}-bats"
+  bandwidth            = "10"
   internet_charge_type = "PayByBandwidth"
 }
 
 resource "alicloud_eip" "natgw" {
-  name = "${var.env_name}-nat-gw"
-  bandwidth = "10"
+  name                 = "${var.env_name}-nat-gw"
+  bandwidth            = "10"
   internet_charge_type = "PayByBandwidth"
 }
 
 resource "alicloud_eip_association" "natgw" {
-  allocation_id = "${alicloud_eip.natgw.id}"
-  instance_id = "${alicloud_nat_gateway.default.id}"
+  allocation_id = alicloud_eip.natgw.id
+  instance_id   = alicloud_nat_gateway.default.id
 }
 
 resource "alicloud_slb" "e2e" {
-  name = "${var.env_name}"
-  vswitch_id = "${alicloud_vswitch.alicloud_resources.id}"
+  name                 = var.env_name
+  vswitch_id           = alicloud_vswitch.alicloud_resources.id
   internet_charge_type = "paybytraffic"
 }
 resource "alicloud_slb_listener" "slb-80-80" {
-    frontend_port = 80
-    protocol = "http"
-    backend_port = 80
-    load_balancer_id = "${alicloud_slb.e2e.id}"
-    bandwidth = 10
-    health_check = "off"
+  frontend_port    = 80
+  protocol         = "http"
+  backend_port     = 80
+  load_balancer_id = alicloud_slb.e2e.id
+  bandwidth        = 10
+  health_check     = "off"
 
 }
 
 resource "alicloud_key_pair" "director" {
-  key_name   = "${var.env_name}"
-  public_key = "${var.public_key}"
+  key_name   = var.env_name
+  public_key = var.public_key
 
 }
 
 output "vpc_id" {
-  value = "${alicloud_vpc.default.id}"
+  value = alicloud_vpc.default.id
 }
 output "region" {
-  value = "${var.region}"
+  value = var.region
 }
 
 # Used by bats
 output "key_pair_name" {
-  value = "${alicloud_key_pair.director.key_name}"
+  value = alicloud_key_pair.director.key_name
 }
 
 output "security_group_id" {
-  value = "${alicloud_security_group.allow_all.id}"
+  value = alicloud_security_group.allow_all.id
 }
 output "external_ip" {
-  value = "${alicloud_eip.director.ip_address}"
+  value = alicloud_eip.director.ip_address
 }
 output "zone" {
-  value = "${alicloud_vswitch.default.availability_zone}"
+  value = alicloud_vswitch.default.availability_zone
 }
 output "vswitch_id" {
-  value = "${alicloud_vswitch.default.id}"
+  value = alicloud_vswitch.default.id
 }
 output "internal_cidr" {
-  value = "${alicloud_vpc.default.cidr_block}"
+  value = alicloud_vpc.default.cidr_block
 }
 output "internal_gw" {
-  value = "${cidrhost(alicloud_vpc.default.cidr_block, 1)}"
+  value = cidrhost(alicloud_vpc.default.cidr_block, 1)
 }
 output "dns_recursor_ip" {
   value = "8.8.8.8"
 }
 output "internal_ip" {
-  value = "${cidrhost(alicloud_vpc.default.cidr_block, 6)}"
+  value = cidrhost(alicloud_vpc.default.cidr_block, 6)
 }
 output "reserved_range" {
   value = "${cidrhost(alicloud_vpc.default.cidr_block, 2)}-${cidrhost(alicloud_vpc.default.cidr_block, 9)}"
@@ -168,15 +168,15 @@ output "static_range" {
   value = "${cidrhost(alicloud_vpc.default.cidr_block, 10)}-${cidrhost(alicloud_vpc.default.cidr_block, 30)}"
 }
 output "bats_eip" {
-  value = "${alicloud_eip.bats.ip_address}"
+  value = alicloud_eip.bats.ip_address
 }
 output "network_static_ip_1" {
-  value = "${cidrhost(alicloud_vpc.default.cidr_block, 29)}"
+  value = cidrhost(alicloud_vpc.default.cidr_block, 29)
 }
 output "network_static_ip_2" {
-  value = "${cidrhost(alicloud_vpc.default.cidr_block, 30)}"
+  value = cidrhost(alicloud_vpc.default.cidr_block, 30)
 }
 
 output "e2e_slb_name" {
-  value = "${alicloud_slb.e2e.id}"
+  value = alicloud_slb.e2e.id
 }

--- a/aws/assets/terraform/template.tf
+++ b/aws/assets/terraform/template.tf
@@ -5,9 +5,9 @@ variable "env_name" {}
 variable "public_key" {}
 
 provider "aws" {
-  access_key = "${var.access_key}"
-  secret_key = "${var.secret_key}"
-  region = "${var.region}"
+  access_key = var.access_key
+  secret_key = var.secret_key
+  region     = var.region
 }
 
 data "aws_availability_zones" "available" {}
@@ -15,7 +15,7 @@ data "aws_availability_zones" "available" {}
 # Create a VPC to launch our instances into
 resource "aws_vpc" "default" {
   assign_generated_ipv6_cidr_block = true
-  cidr_block = "10.0.0.0/16"
+  cidr_block                       = "10.0.0.0/16"
   tags = {
     Name = "${var.env_name}"
   }
@@ -23,17 +23,17 @@ resource "aws_vpc" "default" {
 
 # Create an internet gateway to give our subnet access to the outside world
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
   tags = {
     Name = "${var.env_name}"
   }
 }
 
 resource "aws_route_table" "default" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.default.id}"
+    gateway_id = aws_internet_gateway.default.id
   }
 
   tags = {
@@ -42,16 +42,16 @@ resource "aws_route_table" "default" {
 }
 
 resource "aws_route_table_association" "a" {
-  subnet_id = "${aws_subnet.default.id}"
-  route_table_id = "${aws_route_table.default.id}"
+  subnet_id      = aws_subnet.default.id
+  route_table_id = aws_route_table.default.id
 }
 
 resource "aws_subnet" "default" {
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${cidrsubnet(aws_vpc.default.cidr_block, 8, 0)}"
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 0)}"
-  depends_on = ["aws_internet_gateway.default"]
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  vpc_id            = aws_vpc.default.id
+  cidr_block        = cidrsubnet(aws_vpc.default.cidr_block, 8, 0)
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 0)
+  depends_on        = ["aws_internet_gateway.default"]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "${var.env_name}"
@@ -61,16 +61,16 @@ resource "aws_subnet" "default" {
 }
 
 resource "aws_route_table_association" "aws_resources" {
-  subnet_id = "${aws_subnet.aws_resources.id}"
-  route_table_id = "${aws_route_table.default.id}"
+  subnet_id      = aws_subnet.aws_resources.id
+  route_table_id = aws_route_table.default.id
 }
 
 resource "aws_subnet" "aws_resources" {
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${cidrsubnet(aws_vpc.default.cidr_block, 8, 1)}"
-  ipv6_cidr_block = "${cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)}"
-  depends_on = ["aws_internet_gateway.default"]
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  vpc_id            = aws_vpc.default.id
+  cidr_block        = cidrsubnet(aws_vpc.default.cidr_block, 8, 1)
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.default.ipv6_cidr_block, 8, 1)
+  depends_on        = ["aws_internet_gateway.default"]
+  availability_zone = data.aws_availability_zones.available.names[0]
 
   tags = {
     Name = "${var.env_name}-aws-resources"
@@ -78,24 +78,24 @@ resource "aws_subnet" "aws_resources" {
 }
 
 resource "aws_network_acl" "allow_all" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id     = aws_vpc.default.id
   subnet_ids = ["${aws_subnet.default.id}"]
   egress {
-    protocol = "-1"
-    rule_no = 2
-    action = "allow"
+    protocol   = "-1"
+    rule_no    = 2
+    action     = "allow"
     cidr_block = "0.0.0.0/0"
-    from_port = 0
-    to_port = 0
+    from_port  = 0
+    to_port    = 0
   }
 
   ingress {
-    protocol = "-1"
-    rule_no = 1
-    action = "allow"
+    protocol   = "-1"
+    rule_no    = 1
+    action     = "allow"
     cidr_block = "0.0.0.0/0"
-    from_port = 0
-    to_port = 0
+    from_port  = 0
+    to_port    = 0
   }
 
   tags = {
@@ -104,22 +104,22 @@ resource "aws_network_acl" "allow_all" {
 }
 
 resource "aws_security_group" "allow_all" {
-  vpc_id = "${aws_vpc.default.id}"
-  name = "allow_all-${var.env_name}"
+  vpc_id = aws_vpc.default.id
+  name   = "allow_all-${var.env_name}"
   # description = "Allow all inbound and outgoing traffic"
   description = "Allow local and concourse traffic"
 
   ingress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -139,14 +139,13 @@ resource "aws_eip" "bats" {
 # Create a new classic load balancer
 resource "aws_elb" "e2e" {
   listener {
-    instance_port = 80
+    instance_port     = 80
     instance_protocol = "http"
-    lb_port = 80
-    lb_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
   }
 
-  subnets = [
-    "${aws_subnet.aws_resources.id}"]
+  subnets = ["${aws_subnet.aws_resources.id}"]
 
   tags = {
     Name = "${var.env_name}-e2e"
@@ -154,8 +153,8 @@ resource "aws_elb" "e2e" {
 }
 
 resource "aws_iam_role_policy" "e2e" {
-  name = "${var.env_name}-policy"
-  role = "${aws_iam_role.e2e.id}"
+  name   = "${var.env_name}-policy"
+  role   = aws_iam_role.e2e.id
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -191,11 +190,11 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "e2e" {
-  role = "${aws_iam_role.e2e.name}"
+  role = aws_iam_role.e2e.name
 }
 
 resource "aws_iam_role" "e2e" {
-  name_prefix = "${var.env_name}"
+  name_prefix        = var.env_name
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -214,49 +213,49 @@ EOF
 }
 
 resource "aws_key_pair" "director" {
-  key_name   = "${var.env_name}"
-  public_key = "${var.public_key}"
+  key_name   = var.env_name
+  public_key = var.public_key
 }
 
 resource "aws_kms_key" "key" {
-  description = "${var.env_name}-kms-key"
+  description             = "${var.env_name}-kms-key"
   deletion_window_in_days = 7
 }
 
 output "vpc_id" {
-  value = "${aws_vpc.default.id}"
+  value = aws_vpc.default.id
 }
 output "region" {
-  value = "${var.region}"
+  value = var.region
 }
 
 # Used by bats
 output "default_key_name" {
-  value = "${aws_key_pair.director.key_name}"
+  value = aws_key_pair.director.key_name
 }
 output "default_security_groups" {
   value = ["${aws_security_group.allow_all.name}"]
 }
 output "external_ip" {
-  value = "${aws_eip.director.public_ip}"
+  value = aws_eip.director.public_ip
 }
 output "az" {
-  value = "${aws_subnet.default.availability_zone}"
+  value = aws_subnet.default.availability_zone
 }
 output "subnet_id" {
-  value = "${aws_subnet.default.id}"
+  value = aws_subnet.default.id
 }
 output "internal_cidr" {
-  value = "${aws_vpc.default.cidr_block}"
+  value = aws_vpc.default.cidr_block
 }
 output "internal_gw" {
-  value = "${cidrhost(aws_vpc.default.cidr_block, 1)}"
+  value = cidrhost(aws_vpc.default.cidr_block, 1)
 }
 output "dns_recursor_ip" {
-  value = "${cidrhost(aws_vpc.default.cidr_block, 2)}"
+  value = cidrhost(aws_vpc.default.cidr_block, 2)
 }
 output "internal_ip" {
-  value = "${cidrhost(aws_vpc.default.cidr_block, 6)}"
+  value = cidrhost(aws_vpc.default.cidr_block, 6)
 }
 output "reserved_range" {
   value = "${cidrhost(aws_vpc.default.cidr_block, 2)}-${cidrhost(aws_vpc.default.cidr_block, 9)}"
@@ -265,22 +264,22 @@ output "static_range" {
   value = "${cidrhost(aws_vpc.default.cidr_block, 10)}-${cidrhost(aws_vpc.default.cidr_block, 30)}"
 }
 output "bats_eip" {
-  value = "${aws_eip.bats.public_ip}"
+  value = aws_eip.bats.public_ip
 }
 output "network_static_ip_1" {
-  value = "${cidrhost(aws_vpc.default.cidr_block, 29)}"
+  value = cidrhost(aws_vpc.default.cidr_block, 29)
 }
 output "network_static_ip_2" {
-  value = "${cidrhost(aws_vpc.default.cidr_block, 30)}"
+  value = cidrhost(aws_vpc.default.cidr_block, 30)
 }
 
 # Used by end-2-end tests
 output "iam_instance_profile" {
-  value = "${aws_iam_instance_profile.e2e.name}"
+  value = aws_iam_instance_profile.e2e.name
 }
 output "e2e_elb_name" {
-  value = "${aws_elb.e2e.id}"
+  value = aws_elb.e2e.id
 }
 output "aws_kms_key_arn" {
-  value = "${aws_kms_key.key.arn}"
+  value = aws_kms_key.key.arn
 }

--- a/azure/assets/terraform/terraform.tf
+++ b/azure/assets/terraform/terraform.tf
@@ -68,12 +68,12 @@ resource "azurerm_subnet" "azure_bats_subnet_2" {
 
 # Create a Storage Account in the azure_rg_bosh resouce group
 resource "azurerm_storage_account" "azure_bosh_sa" {
-  name                     = replace(var.env_name, "-", "")
-  resource_group_name      = azurerm_resource_group.azure_rg_bosh.name
-  location                 = var.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  allow_blob_public_access = true
+  name                            = replace(var.env_name, "-", "")
+  resource_group_name             = azurerm_resource_group.azure_rg_bosh.name
+  location                        = var.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = true
 }
 # Create a Storage Container for the bosh director
 resource "azurerm_storage_container" "azure_bosh_container" {

--- a/azure/assets/terraform/terraform.tf
+++ b/azure/assets/terraform/terraform.tf
@@ -145,18 +145,18 @@ resource "azurerm_network_security_group" "azure_bosh_nsg" {
 
 # Public IP Address for bosh
 resource "azurerm_public_ip" "azure_ip_bosh" {
-  name                         = "azure_ip_bosh"
-  location                     = var.location
-  resource_group_name          = azurerm_resource_group.azure_rg_bosh.name
-  allocation_method            = "Static"
+  name                = "azure_ip_bosh"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.azure_rg_bosh.name
+  allocation_method   = "Static"
 }
 
 # Public IP Address for BATS
 resource "azurerm_public_ip" "azure_ip_bats" {
-  name                         = "azure_ip_bats"
-  location                     = var.location
-  resource_group_name          = azurerm_resource_group.azure_rg_bosh.name
-  allocation_method            = "Static"
+  name                = "azure_ip_bats"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.azure_rg_bosh.name
+  allocation_method   = "Static"
 }
 
 output "external_ip" {
@@ -200,22 +200,22 @@ output "bats_public_ip" {
 }
 output "bats_first_network" {
   value = {
-    name = azurerm_subnet.azure_bats_subnet.name
-    cidr = azurerm_subnet.azure_bats_subnet.address_prefix
-    gateway = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 1)
+    name           = azurerm_subnet.azure_bats_subnet.name
+    cidr           = azurerm_subnet.azure_bats_subnet.address_prefix
+    gateway        = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 1)
     reserved_range = "${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 2)}-${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 3)}"
-    static_range =  "${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 10)}"
-    static_ip_1 = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 4)
-    static_ip_2 = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 5)
+    static_range   = "${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 10)}"
+    static_ip_1    = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 4)
+    static_ip_2    = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 5)
   }
 }
 output "bats_second_network" {
   value = {
-    name = azurerm_subnet.azure_bats_subnet_2.name
-    cidr = azurerm_subnet.azure_bats_subnet_2.address_prefix
-    gateway = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 1)
+    name           = azurerm_subnet.azure_bats_subnet_2.name
+    cidr           = azurerm_subnet.azure_bats_subnet_2.address_prefix
+    gateway        = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 1)
     reserved_range = "${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 2)}-${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 3)}"
-    static_range =  "${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 10)}"
-    static_ip_1 = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 4)
+    static_range   = "${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 10)}"
+    static_ip_1    = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 4)
   }
 }

--- a/gcp/assets/terraform/terraform.tf
+++ b/gcp/assets/terraform/terraform.tf
@@ -1,8 +1,8 @@
 variable "env_name" {
-  type = "string"
+  type = string
 }
 variable "google_project" {
-  type = "string"
+  type = string
 }
 variable "google_region" {
   default = "us-central1"
@@ -11,13 +11,13 @@ variable "google_zone" {
   default = "us-central1-a"
 }
 variable "google_json_key_data" {
-  type = "string"
+  type = string
 }
 
 provider "google" {
-  credentials = "${var.google_json_key_data}"
-  project     = "${var.google_project}"
-  region      = "${var.google_region}"
+  credentials = var.google_json_key_data
+  project     = var.google_project
+  region      = var.google_region
 }
 
 resource "google_compute_address" "director" {
@@ -29,19 +29,19 @@ resource "google_compute_address" "bats" {
 }
 
 resource "google_compute_network" "network" {
-  name = "${var.env_name}-custom"
+  name                    = "${var.env_name}-custom"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
   name          = "${var.env_name}-${var.google_region}"
   ip_cidr_range = "10.0.0.0/24"
-  network       = "${google_compute_network.network.self_link}"
+  network       = google_compute_network.network.self_link
 }
 
 resource "google_compute_firewall" "internal" {
   name    = "${var.env_name}-internal"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   description = "BOSH CI Internal traffic"
 
@@ -61,48 +61,48 @@ resource "google_compute_firewall" "internal" {
 
 resource "google_compute_firewall" "external" {
   name    = "${var.env_name}-external"
-  network = "${google_compute_network.network.name}"
+  network = google_compute_network.network.name
 
   description = "BOSH CI External traffic"
 
   allow {
     protocol = "tcp"
-    ports = ["22", "443", "4222", "6868", "25250", "25555", "25777"]
+    ports    = ["22", "443", "4222", "6868", "25250", "25555", "25777"]
   }
   allow {
     protocol = "udp"
-    ports = ["53"]
+    ports    = ["53"]
   }
 
   target_tags = ["${var.env_name}-external"]
 }
 
 output "project_id" {
-  value = "${var.google_project}"
+  value = var.google_project
 }
 output "zone" {
-  value = "${var.google_zone}"
+  value = var.google_zone
 }
 output "network" {
-  value = "${google_compute_network.network.name}"
+  value = google_compute_network.network.name
 }
 output "subnetwork" {
-  value = "${google_compute_subnetwork.subnetwork.name}"
+  value = google_compute_subnetwork.subnetwork.name
 }
 output "internal_cidr" {
-  value = "${google_compute_subnetwork.subnetwork.ip_cidr_range}"
+  value = google_compute_subnetwork.subnetwork.ip_cidr_range
 }
 output "tags" {
-  value = ["${google_compute_firewall.internal.name}","${google_compute_firewall.external.name}"]
+  value = ["${google_compute_firewall.internal.name}", "${google_compute_firewall.external.name}"]
 }
 output "external_ip" {
-  value = "${google_compute_address.director.address}"
+  value = google_compute_address.director.address
 }
 output "internal_ip" {
-  value = "${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 6)}"
+  value = cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 6)
 }
 output "internal_gw" {
-  value = "${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 1)}"
+  value = cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 1)
 }
 output "reserved_range" {
   value = "${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 2)}-${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 15)}"
@@ -112,11 +112,11 @@ output "static_range" {
 }
 
 output "bats_external_ip" {
-  value = "${google_compute_address.bats.address}"
+  value = google_compute_address.bats.address
 }
 output "bats_static_ip_pair" {
-  value = ["${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 17)}","${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 18)}"]
+  value = ["${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 17)}", "${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 18)}"]
 }
 output "bats_static_ip" {
-  value = "${cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 16)}"
+  value = cidrhost(google_compute_subnetwork.subnetwork.ip_cidr_range, 16)
 }


### PR DESCRIPTION
The azurerm terraform provider v3.10 no longer accepts the `azurerm_storage_account` resource argument `allow_blob_public_access`, so we use the replacement `allow_nested_items_to_be_public` instead.

Fixes:
```
Error: Unsupported argument

  on terraform.tf line 76, in resource "azurerm_storage_account" "azure_bosh_sa":
  76:   allow_blob_public_access = true

An argument named "allow_blob_public_access" is not expected here.
```

Drive-by: we ran `terraform fmt` to clean up the `*.tf` files.