### PR TITLE
Use Terrraform's azurerm's `address_prefixes`

### DIFF
--- a/azure/assets/terraform/terraform.tf
+++ b/azure/assets/terraform/terraform.tf
@@ -172,7 +172,7 @@ output "subnet_name" {
   value = azurerm_subnet.azure_bosh_subnet.name
 }
 output "internal_ip" {
-  value = cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefix, 6)
+  value = cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefixes[0], 6)
 }
 output "resource_group_name" {
   value = azurerm_resource_group.azure_rg_bosh.name
@@ -187,13 +187,13 @@ output "default_security_group" {
   value = azurerm_network_security_group.azure_bosh_nsg.name
 }
 output "internal_cidr" {
-  value = azurerm_subnet.azure_bosh_subnet.address_prefix
+  value = azurerm_subnet.azure_bosh_subnet.address_prefixes[0]
 }
 output "internal_gw" {
-  value = cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefix, 1)
+  value = cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefixes[0], 1)
 }
 output "reserved_range" {
-  value = "${cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefix, 2)}-${cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefix, 6)}"
+  value = "${cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefixes[0], 2)}-${cidrhost(azurerm_subnet.azure_bosh_subnet.address_prefixes[0], 6)}"
 }
 output "bats_public_ip" {
   value = azurerm_public_ip.azure_ip_bats.ip_address
@@ -201,21 +201,21 @@ output "bats_public_ip" {
 output "bats_first_network" {
   value = {
     name           = azurerm_subnet.azure_bats_subnet.name
-    cidr           = azurerm_subnet.azure_bats_subnet.address_prefix
-    gateway        = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 1)
-    reserved_range = "${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 2)}-${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 3)}"
-    static_range   = "${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 10)}"
-    static_ip_1    = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 4)
-    static_ip_2    = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefix, 5)
+    cidr           = azurerm_subnet.azure_bats_subnet.address_prefixes[0]
+    gateway        = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefixes[0], 1)
+    reserved_range = "${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefixes[0], 2)}-${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefixes[0], 3)}"
+    static_range   = "${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefixes[0], 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet.address_prefixes[0], 10)}"
+    static_ip_1    = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefixes[0], 4)
+    static_ip_2    = cidrhost(azurerm_subnet.azure_bats_subnet.address_prefixes[0], 5)
   }
 }
 output "bats_second_network" {
   value = {
     name           = azurerm_subnet.azure_bats_subnet_2.name
-    cidr           = azurerm_subnet.azure_bats_subnet_2.address_prefix
-    gateway        = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 1)
-    reserved_range = "${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 2)}-${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 3)}"
-    static_range   = "${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 10)}"
-    static_ip_1    = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefix, 4)
+    cidr           = azurerm_subnet.azure_bats_subnet_2.address_prefixes[0]
+    gateway        = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefixes[0], 1)
+    reserved_range = "${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefixes[0], 2)}-${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefixes[0], 3)}"
+    static_range   = "${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefixes[0], 4)}-${cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefixes[0], 10)}"
+    static_ip_1    = cidrhost(azurerm_subnet.azure_bats_subnet_2.address_prefixes[0], 4)
   }
 }


### PR DESCRIPTION
Our BOSH Director can't be deployed because it's missing crucial output from Terraform; specifically, the output dependent on the deprecated `address_prefix` attribute is lost.

This commit remedies that by using the new attribute (`address_prefixes`, an array) and indexing the first element (`address_prefix` → `address_prefixes[0]`).

Fixes, during `terraform apply`:
```
Warning: Unsupported attribute:This object has no argument, nested block, or exported attribute named "address_prefix". Did you mean "address_prefixes"?
```
Fixes, during `bosh create-env`:
```
Parsing release set manifest '/tmp/build/0e0fd8bf/director-state/director.yml':
  Evaluating manifest:
    - Expected to find variables:
        - internal_cidr
        - internal_gw
        - internal_ip
```