### PR TITLE
Update the path of the stemcell acceptance tests

### DIFF
--- a/shared/tasks/test-stemcell.sh
+++ b/shared/tasks/test-stemcell.sh
@@ -15,11 +15,6 @@ export OS_CONF_RELEASE_PATH=$(realpath os-conf-release/*.tgz)
 export STEMCELL_PATH=$(realpath stemcell/*.tgz)
 export BOSH_stemcell_version=\"$(realpath stemcell/version | xargs -n 1 cat)\"
 
-pushd bosh-linux-stemcell-builder
-  export PATH=/usr/local/go/bin:$PATH
-  export GOPATH=$(pwd)
-
-  pushd src/github.com/cloudfoundry/stemcell-acceptance-tests
-    ./bin/test-smoke $package
-  popd
+pushd bosh-linux-stemcell-builder/acceptance-tests
+  ./bin/test-smoke $package
 popd


### PR DESCRIPTION
These live in `bosh-linux-stemcell-builder` and are migrating out of a pre-go.mod path.